### PR TITLE
Remove map helper methods to support android platform and enable GRIB2's with sections 2

### DIFF
--- a/src/main/java/mt/edu/um/cf2/jgribx/grib2/Grib2Record.java
+++ b/src/main/java/mt/edu/um/cf2/jgribx/grib2/Grib2Record.java
@@ -68,6 +68,7 @@ public class Grib2Record extends GribRecord
                     record.ids = Grib2RecordIDS.readFromStream(in);
                     break;
                 case 2:
+                    in.skip(sectionLength);
                     break;
                 case 3:
                     gds = Grib2RecordGDS.readFromStream(in);
@@ -208,5 +209,21 @@ public class Grib2Record extends GribRecord
         }
         
         return value;
+    }
+
+    /**
+     * Access to grid definition section (GDS) records.
+     * @return GDS records
+     */
+    public List<Grib2RecordGDS> getGDS() {
+        return gdsList;
+    }
+
+    /**
+     * Access to data section (DS) records.
+     * @return DS records
+     */
+    public List<Grib2RecordDS> getDS() {
+        return dsList;
     }
 }

--- a/src/main/java/mt/edu/um/cf2/jgribx/grib2/ParameterCategory.java
+++ b/src/main/java/mt/edu/um/cf2/jgribx/grib2/ParameterCategory.java
@@ -3,10 +3,9 @@ package mt.edu.um.cf2.jgribx.grib2;
 import mt.edu.um.cf2.jgribx.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Map.entry;
 
 public abstract class ParameterCategory
 {
@@ -63,13 +62,15 @@ public abstract class ParameterCategory
 
     public static class Meteorological extends ParameterCategory
     {
-        private static final Map<Integer, String> entries = Map.ofEntries(
-                entry(0, "TEMPERATURE"),
-                entry(1, "MOISTURE"),
-                entry(2, "MOMENTUM"),
-                entry(3, "MASS"),
-                entry(14, "TRACE_GASES")
-        );
+        private static final Map<Integer, String> entries = new HashMap();
+
+        static {
+            entries.put(0, "TEMPERATURE");
+            entries.put(1, "MOISTURE");
+            entries.put(2, "MOMENTUM");
+            entries.put(3, "MASS");
+            entries.put(14, "TRACE_GASES");
+        }
 
         public Meteorological(int categoryId)
         {
@@ -95,10 +96,12 @@ public abstract class ParameterCategory
 
     public static class Hydrological extends ParameterCategory
     {
-        private static final Map<Integer, String> entries = Map.ofEntries(
-                entry(0, "BASIC"),
-                entry(1, "PROBABILITIES")
-        );
+        private static final Map<Integer, String> entries = new HashMap<>();
+
+        static {
+            entries.put(0, "BASIC");
+            entries.put(1, "PROBABILITIES");
+        }
 
         public Hydrological(int categoryId)
         {
@@ -123,10 +126,12 @@ public abstract class ParameterCategory
 
     public static class LandSurface extends ParameterCategory
     {
-        private static final Map<Integer, String> entries = Map.ofEntries(
-                entry(0, "VEGETATION_BIOMASS"),
-                entry(1, "AGRICULTURAL_AQUACULTURAL")
-        );
+        private static final Map<Integer, String> entries = new HashMap<>();
+
+        static {
+            entries.put(0, "VEGETATION_BIOMASS");
+            entries.put(1, "AGRICULTURAL_AQUACULTURAL");
+        }
 
         public LandSurface(int categoryId)
         {
@@ -151,10 +156,12 @@ public abstract class ParameterCategory
 
     public static class SatelliteRemoteSensing extends ParameterCategory
     {
-        private static final Map<Integer, String> entries = Map.ofEntries(
-                entry(0, "IMAGE_FORMAT"),
-                entry(1, "QUANTITATIVE")
-        );
+        private static final Map<Integer, String> entries = new HashMap<>();
+
+        static {
+            entries.put(0, "IMAGE_FORMAT");
+            entries.put(1, "QUANTITATIVE");
+        }
 
         public SatelliteRemoteSensing(int categoryId)
         {
@@ -179,10 +186,12 @@ public abstract class ParameterCategory
 
     public static class Oceanographic extends ParameterCategory
     {
-        private static final Map<Integer, String> entries = Map.ofEntries(
-                entry(0, "WAVES"),
-                entry(1, "CURRENTS")
-        );
+        private static final Map<Integer, String> entries = new HashMap<>();
+
+        static {
+            entries.put(0, "WAVES");
+            entries.put(1, "CURRENTS");
+        }
 
         public Oceanographic(int categoryId)
         {

--- a/src/main/java/mt/edu/um/cf2/jgribx/grib2/ProductDiscipline.java
+++ b/src/main/java/mt/edu/um/cf2/jgribx/grib2/ProductDiscipline.java
@@ -2,21 +2,21 @@ package mt.edu.um.cf2.jgribx.grib2;
 
 import java.util.*;
 
-import static java.util.Map.entry;
-
 public class ProductDiscipline
 {
-    private int value;
-    private String name;
-    private List<ParameterCategory> categories;
+    private final int value;
+    private final String name;
+    private final List<ParameterCategory> categories;
 
-    private static final Map<Integer, String> entries = Map.ofEntries(
-            entry(0, "METEOROLOGICAL"),
-            entry(1, "HYDROLOGICAL"),
-            entry(2, "LAND_SURFACE"),
-            entry(3, "SATELLITE_REMOTE_SENSING"),
-            entry(10, "OCEANOGRAPHIC")
-    );
+    private static final Map<Integer, String> entries = new HashMap<>();
+
+    static {
+        entries.put(0, "METEOROLOGICAL");
+        entries.put(1, "HYDROLOGICAL");
+        entries.put(2, "LAND_SURFACE");
+        entries.put(3, "SATELLITE_REMOTE_SENSING");
+        entries.put(10, "OCEANOGRAPHIC");
+    }
 
     public ProductDiscipline(int discipline)
     {


### PR DESCRIPTION
The `Map.ofEntries` is not supported in android platform. Replaced this with initializing the constant maps in respective static initializers.

Actually skip section 2 in GRIB2 to allow reading of other sections.

Public access to GRIB2's coords and data to allow sequential data processing.
