### PR TITLE
Implementation of unpackDoubleIEEE

### DIFF
--- a/src/main/java/mt/edu/um/cf2/jgribx/Bytes2Number.java
+++ b/src/main/java/mt/edu/um/cf2/jgribx/Bytes2Number.java
@@ -225,5 +225,14 @@ public class Bytes2Number
       return (float) (sgn * Math.pow(16.0, exp - 6) * mant);
    }
 
+	/**
+	 * Convert an array of bytes into a double point precision.
+	 * @param bytes
+	 * @return a single value as a double precision IEEE754 float
+	 */
+	public static double bytesToDobule(byte[] bytes) {
+		return ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).getDouble();
+	}
+   
 }
 

--- a/src/main/java/mt/edu/um/cf2/jgribx/GribInputStream.java
+++ b/src/main/java/mt/edu/um/cf2/jgribx/GribInputStream.java
@@ -362,5 +362,11 @@ public class GribInputStream extends FilterInputStream
        return iEndPos - iStartPos;
    }
 
+   public double readDouble(int nBytes) throws IOException
+   {
+       byte data[] = read(nBytes);
+       return Bytes2Number.bytesToDobule(data);
+   }
+   
 }
 

--- a/src/main/java/mt/edu/um/cf2/jgribx/grib2/Grib2RecordDRS.java
+++ b/src/main/java/mt/edu/um/cf2/jgribx/grib2/Grib2RecordDRS.java
@@ -117,6 +117,33 @@ public class Grib2RecordDRS
                         break;
                 }
                 break;
+            case 4:
+    			/* Grid point data - IEEE floating point data, more at :
+    			 * https://codes.ecmwf.int/grib/format/grib2/templates/5/4/
+    			 * and
+    			 * https://codes.ecmwf.int/grib/format/grib2/ctables/5/7/
+    			 */
+
+    			// [12] Precision
+    			int precision = in.readUINT(1);
+    			drs.missingValue = Float.NaN;
+    			
+    			switch (precision)
+    			{
+    			case 1:
+    				drs.nBits = 32;
+    				break;
+    			case 2:
+    				drs.nBits = 64;
+    				break;
+    			case 3:
+    				drs.nBits = 128;
+    				break;
+    			default:
+    				throw new NotSupportedException("The precision code "+precision+" of floating-point numbers in "
+    						+ drs.packingType +" is not supported");
+    			}
+    			break;
             case 40:
                 /* Grid Point Data - JPEG 2000 code stream format */
                 drs.refValue = in.readFloat(4, FLOAT_IEEE754);

--- a/src/main/java/mt/edu/um/cf2/jgribx/grib2/Grib2RecordDS.java
+++ b/src/main/java/mt/edu/um/cf2/jgribx/grib2/Grib2RecordDS.java
@@ -43,6 +43,9 @@ public class Grib2RecordDS
             case 3:
                 data = unpackComplexPackingAndSpatialDifferencing(in, drs, gds, bms);
                 break;
+    		case 4:
+    			data = unpackDoubleIEEE(in, drs, gds, bms);
+    			break;
             case 40:
                 data = unpackJpeg2000(in, ds.length, drs, gds, bms);
                 break;
@@ -391,6 +394,26 @@ public class Grib2RecordDS
         
         return data;
     }
+    
+    // TODO THIS SHOULD RETURN ARRAY OF DOUBLE !!!
+	private static float[] unpackDoubleIEEE(
+			GribInputStream in, Grib2RecordDRS drs, Grib2RecordGDS gds, Grib2RecordBMS bms
+			) throws IOException, NotSupportedException {
+
+		int nPoints = gds.nDataPoints;
+		float[] values = new float[nPoints];
+
+		if (bms.bitmap != null)	{
+			throw new NotSupportedException("Not yet implemented");
+		} else {
+			
+			Logger.println("Data precission lost (double -> float) in unpackDoubleIEEE", Logger.WARNING);
+			
+			for (int i = 0; i < nPoints; i++) values[i] = (float) in.readDouble(drs.nBits/8);
+		}
+
+		return values;
+	}
     
     private static float[] unpackJpeg2000(GribInputStream in, int dsLength, Grib2RecordDRS drs, Grib2RecordGDS gds,
         Grib2RecordBMS bms) throws IOException, NoValidGribException {


### PR DESCRIPTION
Dear Andrew,

this are my changes regarding the reading and unpacking Double IEEE data .
As you can see the dirty fix is converting the double values to float as they are unpacked 
in method Grib2RecordDS.unpackDoubleIEEE().  (for geopotential there is no loss of precision)

As was mentioned, we are using 64-bit interpretation for geopotential, witch is unnecessary and may be changed in future. However, I believe the unpacking may be useful for ECMWF gribs https://apps.ecmwf.int/ifs-experiments/rd/hej6/
and the double precision should be preserved.

What changes do you suggest to the data flow?

Regards,
Martin