### PR TITLE
Use Cloudsmith for test resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
           environment:
             RES_DIR: src/test/resources
           command: |
+            mdir -p "${RES_DIR}"
             files=(
                 "CF2_20150706_092531.grb"
                 "fh.000_tl.press_ar.octanti"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             )
             for file in "${files[@]}"; do
                 echo "Downloading file: ${file}"
-                curl -1sLf -O "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
+                curl -1sLf "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
             done
             ls ${RES_DIR}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
           command: |
               echo $(cat /etc/os-release)
               echo $(java -version)
+              ls
 
       # Compute checksum of test resources
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
           environment:
             RES_DIR: src/test/resources
           command: |
-            wget --output-document=${RES_DIR}/fh.000_tl.press_ar.octanti "https://www.dropbox.com/s/u32knq1pjm7cq60/fh.000_tl.press_ar.octanti?dl=1"
             curl -1sLf -O "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/issue22.grb"
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
             )
             for file in "${files[@]}"; do
                 echo "Downloading file: ${file}"
-                curl -1sLfv "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
+                curl -1sLf "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
             done
             ls ${RES_DIR}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,11 @@ jobs:
       TERM: dumb
       WGRIB: /home/circleci/repo/wgrib
       GIT_LFS_SKIP_SMUDGE: 1
+      RESOURCE_FILENAMES: |
+        "CF2_20150706_092531.grb"
+        "fh.000_tl.press_ar.octanti"
+        "gfsanl_3_20170512_0000_000.grb2"
+        "issue22.grb"
 
     steps:
       - checkout
@@ -32,14 +37,14 @@ jobs:
           command: |
               echo $(cat /etc/os-release)
               echo $(java -version)
-              ls && ls src && ls src/test && ls src/test/resources
+              ls
 
       # Compute checksum of test resources
       - run:
           name: Compute checksum of test resources
           command: |
-              resources_checksum=($(find src/test/resources -type f -exec md5sum {} \; | sort -k 2 | md5sum))
-              echo Checksum of src/test/resources: $resources_checksum
+              resources_checksum=$(echo "${RESOURCE_FILENAMES" | sort | md5sum)
+              echo Checksum of test resources: $resources_checksum
               echo $resources_checksum > RESOURCES_MD5
 
       # Download and cache dependencies
@@ -52,8 +57,9 @@ jobs:
 
       - run: gradle dependencies
 
+      # TODO Add caching for test resources
       - run:
-          name: "Download GRIB files from Cloudsmith"
+          name: "Download test resources from Cloudsmith"
           environment:
             RES_DIR: src/test/resources
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
 
       - run: gradle dependencies
 
-      # TODO Add caching for test resources
       - run:
           name: "Download test resources from Cloudsmith"
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,9 @@ jobs:
       JVM_OPTS: -Xmx3200m
       TERM: dumb
       WGRIB: /home/circleci/repo/wgrib
+      GIT_LFS_SKIP_SMUDGE: 1
 
     steps:
-      - run:
-          name: Disable LFS pulling
-          command: |
-              git lfs uninstall
       - checkout
 
       # Print some diagnostic info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,10 @@ jobs:
             RES_DIR: src/test/resources
           command: |
             files=(
-                "issue22.grb"
+                "CF2_20150706_092531.grb"
                 "fh.000_tl.press_ar.octanti"
+                "gfsanl_3_20170512_0000_000.grb2"
+                "issue22.grb"
             )
             for file in "${files[@]}"; do
                 echo "Downloading file: ${file}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,8 @@ jobs:
             RES_DIR: src/test/resources
           command: |
             mkdir -p "${RES_DIR}"
-            files=(${RESOURCE_FILENAMES})
+            echo FILENAMES=[${RESOURCE_FILENAMES}]
+            files=("${RESOURCE_FILENAMES}")
             for file in "${files[@]}"; do
                 echo "Downloading file: ${file}"
                 curl --fail --location --silent --show-error --tlsv1 "https://dl.cloudsmith.io/public/jgribx/jgribx/raw/files/${file}" --output "${RES_DIR}/${file}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
             )
             for file in "${files[@]}"; do
                 echo "Downloading file: ${file}"
-                curl -1sLf "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
+                curl --fail --location --silent --show-error --tlsv1 "https://dl.cloudsmith.io/public/jgribx/jgribx/raw/files/${file}" --output "${RES_DIR}/${file}"
             done
             ls ${RES_DIR}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           environment:
             RES_DIR: src/test/resources
           command: |
-            mdir -p "${RES_DIR}"
+            mkdir -p "${RES_DIR}"
             files=(
                 "CF2_20150706_092531.grb"
                 "fh.000_tl.press_ar.octanti"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
                 echo "Downloading file: ${file}"
                 curl -1sLf -O "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
             done
+            ls ${RES_DIR}
 
       - save_cache:
           name: Cache Gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,17 +64,12 @@ jobs:
             RES_DIR: src/test/resources
           command: |
             mkdir -p "${RES_DIR}"
-            files=(
-                "CF2_20150706_092531.grb"
-                "fh.000_tl.press_ar.octanti"
-                "gfsanl_3_20170512_0000_000.grb2"
-                "issue22.grb"
-            )
+            files=(${RESOURCE_FILENAMES})
             for file in "${files[@]}"; do
                 echo "Downloading file: ${file}"
                 curl --fail --location --silent --show-error --tlsv1 "https://dl.cloudsmith.io/public/jgribx/jgribx/raw/files/${file}" --output "${RES_DIR}/${file}"
             done
-            ls ${RES_DIR}
+            ls -hl ${RES_DIR}
 
       - save_cache:
           name: Cache Gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: |
             mkdir -p "${RES_DIR}"
             echo FILENAMES=[${RESOURCE_FILENAMES}]
-            files=("${RESOURCE_FILENAMES}")
+            files=(${RESOURCE_FILENAMES})
             for file in "${files[@]}"; do
                 echo "Downloading file: ${file}"
                 curl --fail --location --silent --show-error --tlsv1 "https://dl.cloudsmith.io/public/jgribx/jgribx/raw/files/${file}" --output "${RES_DIR}/${file}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,21 +50,6 @@ jobs:
 
       - run: gradle dependencies
 
-      - run:
-            name: Install Git LFS
-            command: |
-                curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
-                sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
-                sudo apt-get update
-                sudo apt-get install libcrypt1 || [[ $? -eq 100 ]]
-                sudo apt-get install git-lfs
-
-      - restore_cache:
-          name: Restore Git LFS files from cache
-          keys:
-            - git-lfs-cache-{{ checksum "RESOURCES_MD5" }}
-            - git-lfs-cache-
-
       # Download additional GRIB files from Dropbox
       - run:
           name: "Download GRIB files from Dropbox"
@@ -73,13 +58,6 @@ jobs:
           command: |
             wget --output-document=${RES_DIR}/fh.000_tl.press_ar.octanti "https://www.dropbox.com/s/u32knq1pjm7cq60/fh.000_tl.press_ar.octanti?dl=1"
             curl -1sLf -O "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/issue22.grb"
-
-      # Cache Git LFS files
-      - save_cache:
-            name: Cache Git LFS files
-            key: git-lfs-cache-{{ checksum "RESOURCES_MD5" }}
-            paths:
-              - .git/lfs/objects
 
       - save_cache:
           name: Cache Gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,11 @@ jobs:
       WGRIB: /home/circleci/repo/wgrib
 
     steps:
-      - checkout
       - run:
           name: Disable LFS pulling
           command: |
               git lfs uninstall
+      - checkout
 
       # Print some diagnostic info
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             RES_DIR: src/test/resources
           command: |
             wget --output-document=${RES_DIR}/fh.000_tl.press_ar.octanti "https://www.dropbox.com/s/u32knq1pjm7cq60/fh.000_tl.press_ar.octanti?dl=1"
-            wget --output-document=${RES_DIR}/issue22.grb "https://www.dropbox.com/scl/fi/o9o79d6snz9j8ige91ezh/issue22.grb?rlkey=y9jxro8eqvkt1kd7kil0i1xb7&st=wznfrhvy&dl=1"
+            curl -1sLf -O "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/issue22.grb"
 
       # Cache Git LFS files
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,10 @@ jobs:
       WGRIB: /home/circleci/repo/wgrib
       GIT_LFS_SKIP_SMUDGE: 1
       RESOURCE_FILENAMES: >
-        "CF2_20150706_092531.grb"
-        "fh.000_tl.press_ar.octanti"
-        "gfsanl_3_20170512_0000_000.grb2"
-        "issue22.grb"
+        CF2_20150706_092531.grb
+        fh.000_tl.press_ar.octanti
+        gfsanl_3_20170512_0000_000.grb2
+        issue22.grb
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       TERM: dumb
       WGRIB: /home/circleci/repo/wgrib
       GIT_LFS_SKIP_SMUDGE: 1
-      RESOURCE_FILENAMES: |
+      RESOURCE_FILENAMES: >
         "CF2_20150706_092531.grb"
         "fh.000_tl.press_ar.octanti"
         "gfsanl_3_20170512_0000_000.grb2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
                 "issue22.grb"
                 "fh.000_tl.press_ar.octanti"
             )
-            for file in "files[@]"; do
+            for file in "${files[@]}"; do
                 echo "Downloading file: ${file}"
                 curl -1sLf -O "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,9 @@ jobs:
     steps:
       - checkout
       - run:
-        name: Disable LFS pulling
-        command: |
-            git lfs uninstall
+          name: Disable LFS pulling
+          command: |
+              git lfs uninstall
 
       # Print some diagnostic info
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,13 +51,19 @@ jobs:
 
       - run: gradle dependencies
 
-      # Download additional GRIB files from Dropbox
       - run:
-          name: "Download GRIB files from Dropbox"
+          name: "Download GRIB files from Cloudsmith"
           environment:
             RES_DIR: src/test/resources
           command: |
-            curl -1sLf -O "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/issue22.grb"
+            files=(
+                "issue22.grb"
+                "fh.000_tl.press_ar.octanti"
+            )
+            for file in "files[@]"; do
+                echo "Downloading file: ${file}"
+                curl -1sLf -O "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
+            done
 
       - save_cache:
           name: Cache Gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,12 +65,6 @@ jobs:
             - git-lfs-cache-{{ checksum "RESOURCES_MD5" }}
             - git-lfs-cache-
 
-      - run:
-            name: Pull Git LFS files
-            command: |
-                git lfs install
-                git lfs pull
-
       # Download additional GRIB files from Dropbox
       - run:
           name: "Download GRIB files from Dropbox"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             )
             for file in "${files[@]}"; do
                 echo "Downloading file: ${file}"
-                curl -1sLf "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
+                curl -1sLfv "https://dl.cloudsmith.io/${CLOUDSMITH_TOKEN}/jgribx/grib-files/raw/files/${file}" --output "${RES_DIR}/${file}"
             done
             ls ${RES_DIR}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,10 @@ jobs:
 
     steps:
       - checkout
+      - run:
+        name: Disable LFS pulling
+        command: |
+            git lfs uninstall
 
       # Print some diagnostic info
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Compute checksum of test resources
           command: |
-              resources_checksum=$(echo "${RESOURCE_FILENAMES" | sort | md5sum)
+              resources_checksum=$(echo "${RESOURCE_FILENAMES}" | sort | md5sum)
               echo Checksum of test resources: $resources_checksum
               echo $resources_checksum > RESOURCES_MD5
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: |
               echo $(cat /etc/os-release)
               echo $(java -version)
-              ls
+              ls && ls src && ls src/test && ls src/test/resources
 
       # Compute checksum of test resources
       - run:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.grb filter=lfs diff=lfs merge=lfs -text
-*.grb2 filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![spidru](https://circleci.com/gh/spidru/JGribX.svg?style=shield)](https://circleci.com/gh/spidru/JGribX)
 
-**NOTE: Since commit 1f3fd1e (19th March 2020), the history of this repository has been rewritten to migrate binary files (.grb and .grb2) to Git LFS. Anyone checking out the repository should clone it again rather than pulling.**
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square)](https://cloudsmith.com)
 
 ## Introduction
 JGribX is a GRIB decoder written in Java. It is essentially a fork of [JGrib](http://jgrib.sourceforge.net/), which as far as I know is now no longer being actively developed. JGribX currently supports both GRIB-1 and GRIB-2 files.

--- a/src/test/resources/CF2_20150706_092531.grb
+++ b/src/test/resources/CF2_20150706_092531.grb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97882f906259a97396c15823a42007d21da81609c574e14264bbaa20ef17a884
-size 1293682

--- a/src/test/resources/gfsanl_3_20160324_0600_000.grb
+++ b/src/test/resources/gfsanl_3_20160324_0600_000.grb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f9d960d5225f742b422f82c32a01be6fa281548f7946dd69a9daa6702db4c9f
-size 30903842

--- a/src/test/resources/gfsanl_3_20160324_1200_000.grb
+++ b/src/test/resources/gfsanl_3_20160324_1200_000.grb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:514ed2b980796ead16f1adfc4deb2d0761956d8c25a087a3519d1ec9514c94fc
-size 30998602

--- a/src/test/resources/gfsanl_3_20170512_0000_000.grb2
+++ b/src/test/resources/gfsanl_3_20170512_0000_000.grb2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:439f4eb4795164115665e8e4d457aecaf311873f3e45cd554a296980f17436f5
-size 19297599


### PR DESCRIPTION
Replace Git LFS (GitHub) with Cloudsmith for hosting the test resources (i.e. GRIB files).

Resolves #25.